### PR TITLE
feat: add `nu.exe` to default `skip_close_confirmation_for_processes_named`

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1673,6 +1673,7 @@ fn default_stateless_process_list() -> Vec<String> {
         "fish",
         "tmux",
         "nu",
+        "nu.exe",
         "cmd.exe",
         "pwsh.exe",
         "powershell.exe",


### PR DESCRIPTION
It's obvious that Nushell is intended to be skipped by default for close
confirmation. However, on Windows, Nushell instances are named `nu.exe`,
not `nu`, so they don't get skip-closed properly. Add `nu.exe` alongside
`nu`, so Windows behaves as expected.
